### PR TITLE
Upstream gokrb5 api breaks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "6a1fa9404c0aebf36c879bc50152edcc953910d2"
+  revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
 
 [[projects]]
   branch = "master"
@@ -34,19 +34,20 @@
 [[projects]]
   name = "github.com/xinsnake/go-http-digest-auth-client"
   packages = ["."]
-  revision = "ddd37fe1722021e526546a269b5b5829a3d7b109"
+  revision = "366760120fe0342664d581b235be4eb08aca8834"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["md4","pbkdf2"]
-  revision = "7f7c0c2d75ebb4e32a21396ce36e87b6dadc91c9"
+  revision = "9419663f5a44be8b34ca85f08abc5fe1be11f8a3"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp"]
-  revision = "054b33e6527139ad5b1ec2f6232c3b175bd9a30c"
+  revision = "1087133bc4af3073e18add999345c6ae75918503"
 
 [[projects]]
   name = "gopkg.in/jcmturner/aescts.v1"
@@ -57,12 +58,12 @@
 [[projects]]
   name = "gopkg.in/jcmturner/gokrb5.v1"
   packages = ["asn1tools","client","config","credentials","crypto","crypto/common","crypto/etype","crypto/rfc3961","crypto/rfc3962","crypto/rfc4757","crypto/rfc8009","gssapi","iana","iana/adtype","iana/asnAppTag","iana/chksumtype","iana/errorcode","iana/etypeID","iana/flags","iana/keyusage","iana/msgtype","iana/nametype","iana/patype","keytab","krberror","messages","mstypes","ndr","pac","types"]
-  revision = "f5b5d035fe8c9212b223058a3a8c22c099e623cf"
-  version = "v1.1.3"
+  revision = "ab3cf9b73d364620add518ba8fcfaa67a6c37649"
+  version = "v1.2.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bd9d17a95e066641ed78da4e8044d997e2686ea4c10549684ec833b79d8de791"
+  inputs-digest = "b65d0123d2b03cf1df895c14308b8f5328335b0c86c57e6cd4597488262e3751"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,6 +23,10 @@
 
 [[constraint]]
   branch = "master"
+  name = "github.com/golang/protobuf"
+
+[[constraint]]
+  branch = "master"
   name = "github.com/hashicorp/go-cleanhttp"
 
 [[constraint]]
@@ -31,8 +35,12 @@
 
 [[constraint]]
   name = "github.com/xinsnake/go-http-digest-auth-client"
-  revision = "ddd37fe1722021e526546a269b5b5829a3d7b109"
+  version = "0.3.0"
 
 [[constraint]]
-  name = "github.com/jcmturner/gokrb5"
-  revision = "c26bda0a3bb400baa018645465f49407ef530f27"
+  branch = "master"
+  name = "golang.org/x/net"
+
+[[constraint]]
+  name = "gopkg.in/jcmturner/gokrb5.v1"
+  version = "1.2.0"

--- a/http_client.go
+++ b/http_client.go
@@ -119,7 +119,13 @@ func NewHTTPClient(host string, authenticationConf httpClientAuthConfig) (*httpC
 				return nil, fmt.Errorf("error performing kerberos login with keytab: %s", err)
 			}
 
-			kc.EnableAutoSessionRenewal()
+			session, err := kc.GetSessionFromRealm(authenticationConf.principal.realm)
+
+			if err != nil {
+				return nil, fmt.Errorf("error getting session from realm name: %s", err)
+			}
+
+			kc.EnableAutoSessionRenewal(session)
 
 			c.kerberosClient = kc
 		}

--- a/moby.yml
+++ b/moby.yml
@@ -15,12 +15,12 @@
 #
 services:
   - id: phoenix
-    image: boostport/hbase-phoenix-all-in-one:1.2-4.11
+    image: boostport/hbase-phoenix-all-in-one:1.3-4.12
     ports:
       - "8765"
 
 dev:
-  image: golang:1.8-alpine
+  image: golang:1.9-alpine
   env:
     AVATICA_HOST: http://phoenix:8765
   steps:

--- a/wercker.yml
+++ b/wercker.yml
@@ -14,13 +14,13 @@
 # limitations under the License.
 #
 box:
-  id: golang:1.8-alpine
+  id: golang:1.9-alpine
   cmd: /bin/sh
 
 no-response-timeout: 20
 
 services:
-  - boostport/hbase-phoenix-all-in-one:1.2-4.11
+  - boostport/hbase-phoenix-all-in-one:1.3-4.12
 
 build:
   steps:


### PR DESCRIPTION
There were some breaking API changes in the latest version of gokrb5. This PR contains the required changes to use the latest gokrb5 1.2.0.