### PR TITLE
Check files for Apache license header in make-release-artifacts script

### DIFF
--- a/make-release-artifacts.sh
+++ b/make-release-artifacts.sh
@@ -7,6 +7,15 @@ git fetch --tags
 
 # Get latest tag name
 latestTag=$(git describe --tags `git rev-list --tags --max-count=1` | sed -e 's/-rc[0-9][0-9]*//')
+
+# Exclude files without the Apache license header
+for i in $(git ls-files); do
+   case "$i" in
+   (LICENSE|NOTICE|message/common.pb.go|message/requests.pb.go|message/responses.pb.go|test-fixtures/calcite.png|Gopkg.lock|Gopkg.toml);; # add exceptions here
+   (*) grep -q "Licensed to the Apache Software Foundation" $i || echo "$i has no header";;
+   esac
+done
+
 product=apache-calcite-avatica-go
 tarFile=$product-src-$latestTag.tar.gz
 

--- a/make-release-artifacts.sh
+++ b/make-release-artifacts.sh
@@ -1,3 +1,20 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Clean dist directory
 rm -rf dist
 mkdir -p dist
@@ -5,25 +22,45 @@ mkdir -p dist
 # Get new tags from remote
 git fetch --tags
 
-# Get latest tag name
-latestTag=$(git describe --tags `git rev-list --tags --max-count=1` | sed -e 's/-rc[0-9][0-9]*//')
+# Prompt for tag to release (defaults to latest tag)
+echo -n "Enter tag to release (default: latest tag): "
+read tag
+
+if [[ -z $tag ]]; then
+    tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+    echo "No tag provided. Using the latest tag: $tag"
+fi
 
 # Exclude files without the Apache license header
 for i in $(git ls-files); do
    case "$i" in
-   (LICENSE|NOTICE|message/common.pb.go|message/requests.pb.go|message/responses.pb.go|test-fixtures/calcite.png|Gopkg.lock|Gopkg.toml);; # add exceptions here
+   # The following are excluded from the license header check
+
+   # License files
+   (LICENSE|NOTICE);;
+
+   # Generated files
+   (message/common.pb.go|message/requests.pb.go|message/responses.pb.go|Gopkg.lock|Gopkg.toml);;
+
+   # Binaries
+   (test-fixtures/calcite.png);;
+
    (*) grep -q "Licensed to the Apache Software Foundation" $i || echo "$i has no header";;
    esac
 done
 
+tagWithoutRC=$(echo $tag | sed -e 's/-rc[0-9][0-9]*//')
 product=apache-calcite-avatica-go
-tarFile=$product-src-$latestTag.tar.gz
+tarFile=$product-src-$tagWithoutRC.tar.gz
 
-# Checkout latest tag
-git checkout $latestTag
+# Checkout tag
+if ! git checkout $tag; then
+    echo "Could not check out tag $tag. Does it exist?"
+    exit 1
+fi
 
 # Make tar
-tar -zcvf dist/$tarFile --transform "s/^\./$product-src-$latestTag/g" --exclude "dist" --exclude ".git" .
+tar -zcvf dist/$tarFile --transform "s/^\./$product-src-$tagWithoutRC/g" --exclude "dist" --exclude ".git" .
 
 cd dist
 

--- a/site/go_development.md
+++ b/site/go_development.md
@@ -68,4 +68,6 @@ If you have not set up a GPG signing key, set one up by following these [instruc
 
 From the root of the repository, run `./make-release-artifacts.sh`.
 
+You will be asked to select the tag to build release artifacts for. The latest tag is automatically selected if no tag is selected.
+
 The release artifacts will be placed in the `dist/` folder.


### PR DESCRIPTION
cc @julianhyde 

One quick question:

In cb2d4cb4596d5850bd0eb10c9c7697b679aabc2d, the script was updated to strip `-rc` identifiers from the tag name. Unfortunately, this means that if we only have a tag such as `3.0.0-rc1`, the tag won't be checked out. Should we revert it back to just: `latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)` ?