### PR TITLE
Change UUID package to github.com/hashicorp/go-uuid

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,12 +23,6 @@
   revision = "2aebee971930cd0dd525873330952ab7df5ac95c"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/satori/go.uuid"
-  packages = ["."]
-  revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"
-
-[[projects]]
   name = "github.com/xinsnake/go-http-digest-auth-client"
   packages = ["."]
   revision = "366760120fe0342664d581b235be4eb08aca8834"
@@ -105,6 +99,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "59f780040e7b6a2bfdfff74142a368c4e1c7967769977b14494c3d7f3c5a29e2"
+  inputs-digest = "013ea49100cb3f3a5edfe9778567a160acc63d92dd13d8b2c58394d08f462256"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,10 +30,6 @@
   version = "1.0.0"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/satori/go.uuid"
-
-[[constraint]]
   name = "github.com/xinsnake/go-http-digest-auth-client"
   version = "0.3.0"
 

--- a/driver.go
+++ b/driver.go
@@ -40,7 +40,7 @@ import (
 	"github.com/apache/calcite-avatica-go/hsqldb"
 	"github.com/apache/calcite-avatica-go/message"
 	"github.com/apache/calcite-avatica-go/phoenix"
-	"github.com/satori/go.uuid"
+	"github.com/hashicorp/go-uuid"
 	"golang.org/x/net/context"
 )
 
@@ -72,8 +72,7 @@ func (a *Driver) Open(dsn string) (driver.Conn, error) {
 		return nil, fmt.Errorf("Unable to create HTTP client: %s", err)
 	}
 
-	connectionId, err := uuid.NewV4()
-
+	connectionId, err := uuid.GenerateUUID()
 	if err != nil {
 		return nil, fmt.Errorf("Error generating connection id: %s", err)
 	}
@@ -92,14 +91,14 @@ func (a *Driver) Open(dsn string) (driver.Conn, error) {
 	}
 
 	conn := &conn{
-		connectionId: connectionId.String(),
+		connectionId: connectionId,
 		httpClient:   httpClient,
 		config:       config,
 	}
 
 	// Open a connection to the server
 	req := &message.OpenConnectionRequest{
-		ConnectionId: connectionId.String(),
+		ConnectionId: connectionId,
 		Info:         info,
 	}
 
@@ -114,7 +113,7 @@ func (a *Driver) Open(dsn string) (driver.Conn, error) {
 	}
 
 	response, err := httpClient.post(context.Background(), &message.DatabasePropertyRequest{
-		ConnectionId: connectionId.String(),
+		ConnectionId: connectionId,
 	})
 
 	if err != nil {


### PR DESCRIPTION
The satori UUID package causes problems with go get and vgo when
building multiple database drivers in the same Go application. This is
because the satori package introduced breaking API changes and has not
tagged it a new version yet.

This change converts the connection ID generation to use the hashicorp
UUID package which was already a dependency of this project, as it is a
dependency of the gokrb package.

This has the added benefit of reducing the number of total package
dependencies by 1.

Additionally, this is needed by github.com/xo/usql so that go get and
vgo build both work "out of the box".

The following is a small Go program that demonstrates that the UUIDs
generated will be the same format:

```
package main

import (
	"log"

	guuid "github.com/google/uuid"
	huuid "github.com/hashicorp/go-uuid"
	suuid "github.com/satori/go.uuid"
)

func main() {
	g, err := guuid.NewRandom()
	if err != nil {
		log.Fatal(err)
	}

	h, err := huuid.GenerateUUID()
	if err != nil {
		log.Fatal(err)
	}

	s, err := suuid.NewV4()
	if err != nil {
		log.Fatal(err)
	}

	log.Printf(
		"google: %s, hashicorp: %s, satori: %s",
		g, h, s,
	)
}
```