### PR TITLE
add support for bearer token authentication.

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -62,6 +62,7 @@ func (a *Driver) Open(dsn string) (driver.Conn, error) {
 		authenticationType:  config.authentication,
 		username:            config.avaticaUser,
 		password:            config.avaticaPassword,
+		token:               config.token,
 		principal:           config.principal,
 		keytab:              config.keytab,
 		krb5Conf:            config.krb5Conf,


### PR DESCRIPTION
**What**

Add support for bearer tokens for authentication.

* parse `token=xxxxxx` from DSN
* introduce new auth type `token`
* set `Authorization: Bearer $TOKEN` when auth type is `token` and the token is specified in http client
* slightly cleaned up the if/else statements regarding auth management

**Why**

We need to supply an authorization header in order to access our setup. This may be usefull for others as well, since it would enable us to place  avatica behind some kind of oauth proxy.