### PR TITLE
forward all query parameters from the dsn in the OpenConnectionRequest info object.

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -82,6 +82,12 @@ func (a *Driver) Open(dsn string) (driver.Conn, error) {
 		"Consistency": "8",
 	}
 
+	for key, vals := range config.rawQuery {
+		if len(vals) > 0 {
+			info[key] = vals[0]
+		}
+	}
+
 	if config.user != "" {
 		info["user"] = config.user
 	}

--- a/dsn.go
+++ b/dsn.go
@@ -53,6 +53,8 @@ type Config struct {
 	keytab              string
 	krb5Conf            string
 	krb5CredentialCache string
+
+	rawQuery url.Values
 }
 
 type krb5Principal struct {
@@ -76,6 +78,10 @@ func ParseDSN(dsn string) (*Config, error) {
 		return nil, fmt.Errorf("Unable to parse DSN: %s", err)
 	}
 
+	queries := parsed.Query()
+
+	conf.rawQuery = queries
+
 	userInfo := parsed.User
 
 	if userInfo != nil {
@@ -87,8 +93,6 @@ func ParseDSN(dsn string) (*Config, error) {
 			conf.password = pass
 		}
 	}
-
-	queries := parsed.Query()
 
 	if v := queries.Get("maxRowsTotal"); v != "" {
 


### PR DESCRIPTION
**What**

* save all the query parameters from the DSN in the config object
* map these parameters to the info object of the OpenConnectionRequest message

**Why**

This way we can supply arbitary additional parameters for usecase specific backend behavior. Currently we are using this to specify the scope of the operation (which DB in particular)