### PR TITLE
[CALCITE-3248] add Connector implementation

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -43,9 +43,6 @@ type Config struct {
 	schema               string
 	transactionIsolation uint32
 
-	user     string
-	password string
-
 	authentication      authentication
 	avaticaUser         string
 	avaticaPassword     string
@@ -74,18 +71,6 @@ func ParseDSN(dsn string) (*Config, error) {
 
 	if err != nil {
 		return nil, fmt.Errorf("Unable to parse DSN: %s", err)
-	}
-
-	userInfo := parsed.User
-
-	if userInfo != nil {
-		if userInfo.Username() != "" {
-			conf.user = userInfo.Username()
-		}
-
-		if pass, ok := userInfo.Password(); ok {
-			conf.password = pass
-		}
 	}
 
 	queries := parsed.Query()

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -25,18 +25,10 @@ import (
 
 func TestParseDSN(t *testing.T) {
 
-	config, err := ParseDSN("http://username:password@localhost:8765/myschema?maxRowsTotal=1&frameMaxSize=1&location=Australia/Melbourne&transactionIsolation=8&authentication=BASIC&avaticaUser=someuser&avaticaPassword=somepassword")
+	config, err := ParseDSN("http://localhost:8765/myschema?maxRowsTotal=1&frameMaxSize=1&location=Australia/Melbourne&transactionIsolation=8&authentication=BASIC&avaticaUser=someuser&avaticaPassword=somepassword")
 
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
-	}
-
-	if config.user != "username" {
-		t.Errorf("Expected username to be %s, got %s", "username", config.user)
-	}
-
-	if config.password != "password" {
-		t.Errorf("Expected password to be %s, got %s", "password", config.password)
 	}
 
 	if config.endpoint != "http://localhost:8765/myschema" {
@@ -91,14 +83,6 @@ func TestDSNDefaults(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
-	}
-
-	if config.user != "" {
-		t.Errorf("Default username should be empty, got %s", config.user)
-	}
-
-	if config.password != "" {
-		t.Errorf("Default password should be empty, got %s", config.password)
 	}
 
 	if config.location.String() == "" {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03 // indirect
+	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/xinsnake/go-http-digest-auth-client v0.4.0
 	golang.org/x/crypto v0.0.0-20190424203555-c05e17bb3b2d // indirect
 	gopkg.in/jcmturner/aescts.v1 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,16 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03 h1:FUwcHNlEqkqLjLBdCp5PRlCFijNjvcYANOZXzCfXwCM=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/xinsnake/go-http-digest-auth-client v0.4.0 h1:tTaEBUSDiMi7RDIuj0fy/pszIub8g2DmLjTelB3/3Tk=
 github.com/xinsnake/go-http-digest-auth-client v0.4.0/go.mod h1:QK1t1v7ylyGb363vGWu+6Irh7gyFj+N7+UZzM0L6g8I=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/http_client.go
+++ b/http_client.go
@@ -31,36 +31,16 @@ import (
 
 	avaticaMessage "github.com/apache/calcite-avatica-go/v4/message"
 	"github.com/golang/protobuf/proto"
-	"github.com/xinsnake/go-http-digest-auth-client"
-	"gopkg.in/jcmturner/gokrb5.v7/client"
-	"gopkg.in/jcmturner/gokrb5.v7/config"
-	"gopkg.in/jcmturner/gokrb5.v7/credentials"
-	"gopkg.in/jcmturner/gokrb5.v7/keytab"
-	gokrbSPNEGO "gopkg.in/jcmturner/gokrb5.v7/spnego"
 )
 
 var (
 	badConnRe = regexp.MustCompile(`org\.apache\.calcite\.avatica\.NoSuchConnectionException`)
 )
 
-type httpClientAuthConfig struct {
-	authenticationType authentication
-
-	username string
-	password string
-
-	principal           krb5Principal
-	keytab              string
-	krb5Conf            string
-	krb5CredentialCache string
-}
-
 // httpClient wraps the default http.Client to communicate with the Avatica server.
 type httpClient struct {
-	host           string
-	authConfig     httpClientAuthConfig
-	httpClient     *http.Client
-	kerberosClient *client.Client
+	host       string
+	httpClient *http.Client
 }
 
 type avaticaError struct {
@@ -72,13 +52,10 @@ func (e avaticaError) Error() string {
 }
 
 // NewHTTPClient creates a new httpClient from a host.
-func NewHTTPClient(host string, authenticationConf httpClientAuthConfig) (*httpClient, error) {
+func NewHTTPClient(host string, baseClient *http.Client, config *Config) (*httpClient, error) {
 
-	c := &httpClient{
-		host:       host,
-		authConfig: authenticationConf,
-
-		httpClient: &http.Client{
+	if baseClient == nil {
+		baseClient = &http.Client{
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{
@@ -92,54 +69,26 @@ func NewHTTPClient(host string, authenticationConf httpClientAuthConfig) (*httpC
 				ExpectContinueTimeout: 1 * time.Second,
 				MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
 			},
-		},
+		}
+		switch config.authentication {
+		case digest:
+			baseClient = WithDigestAuth(baseClient, config.avaticaUser, config.avaticaPassword)
+		case basic:
+			baseClient = WithBasicAuth(baseClient, config.avaticaUser, config.avaticaPassword)
+		case spnego:
+			user := config.principal.username
+			realm := config.principal.realm
+			cli, err := WithKerberosAuth(baseClient, user, realm, config.keytab, config.krb5Conf, config.krb5CredentialCache)
+			if err != nil {
+				return nil, err
+			}
+			baseClient = cli
+		}
 	}
 
-	if authenticationConf.authenticationType == digest {
-		rt := digest_auth_client.NewTransport(authenticationConf.username, authenticationConf.password)
-		c.httpClient.Transport = &rt
-
-	} else if authenticationConf.authenticationType == spnego {
-
-		if authenticationConf.krb5CredentialCache != "" {
-
-			tc, err := credentials.LoadCCache(authenticationConf.krb5CredentialCache)
-
-			if err != nil {
-				return nil, fmt.Errorf("error reading kerberos ticket cache: %s", err)
-			}
-
-			kc, err := client.NewClientFromCCache(tc, config.NewConfig())
-			if err != nil {
-				return nil, fmt.Errorf("error creating kerberos client: %s", err)
-			}
-
-			c.kerberosClient = kc
-
-		} else {
-
-			cfg, err := config.Load(authenticationConf.krb5Conf)
-
-			if err != nil {
-				return nil, fmt.Errorf("error reading kerberos config: %s", err)
-			}
-
-			kt, err := keytab.Load(authenticationConf.keytab)
-
-			if err != nil {
-				return nil, fmt.Errorf("error reading kerberos keytab: %s", err)
-			}
-
-			kc := client.NewClientWithKeytab(authenticationConf.principal.username, authenticationConf.principal.realm, kt, cfg)
-
-			err = kc.Login()
-
-			if err != nil {
-				return nil, fmt.Errorf("error performing kerberos login with keytab: %s", err)
-			}
-
-			c.kerberosClient = kc
-		}
+	c := &httpClient{
+		host:       host,
+		httpClient: baseClient,
 	}
 
 	return c, nil
@@ -172,16 +121,6 @@ func (c *httpClient) post(ctx context.Context, message proto.Message) (proto.Mes
 	}
 
 	req.Header.Set("Content-Type", "application/x-google-protobuf")
-
-	if c.authConfig.authenticationType == basic {
-		req.SetBasicAuth(c.authConfig.username, c.authConfig.password)
-	} else if c.authConfig.authenticationType == spnego {
-		err := gokrbSPNEGO.SetSPNEGOHeader(c.kerberosClient, req, "")
-
-		if err != nil{
-			return nil, err
-		}
-	}
 
 	req = req.WithContext(ctx)
 

--- a/http_client_wrappers.go
+++ b/http_client_wrappers.go
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package avatica
+
+import (
+	"fmt"
+	"net/http"
+
+	digest_auth_client "github.com/xinsnake/go-http-digest-auth-client"
+	"gopkg.in/jcmturner/gokrb5.v7/client"
+	"gopkg.in/jcmturner/gokrb5.v7/config"
+	"gopkg.in/jcmturner/gokrb5.v7/credentials"
+	"gopkg.in/jcmturner/gokrb5.v7/keytab"
+	gokrbSPNEGO "gopkg.in/jcmturner/gokrb5.v7/spnego"
+)
+
+// WithDigestAuth takes an http client and prepares it to authenticate using digest authentication
+func WithDigestAuth(cli *http.Client, username, password string) *http.Client {
+	rt := digest_auth_client.NewTransport(username, password)
+	cli.Transport = &rt
+	return cli
+}
+
+// WithBasicAuth takes an http client and prepares it to authenticate using basic authentication
+func WithBasicAuth(cli *http.Client, username, password string) *http.Client {
+	rt := &basicAuthTransport{cli.Transport, username, password}
+	cli.Transport = rt
+	return cli
+}
+
+// WithKerberosAuth takes an http client prepares it to authenticate using kerberos
+func WithKerberosAuth(cli *http.Client, username, realm, keyTab, krb5Conf, krb5CredentialCache string) (*http.Client, error) {
+	var kerberosClient *client.Client
+	if krb5CredentialCache != "" {
+		tc, err := credentials.LoadCCache(krb5CredentialCache)
+		if err != nil {
+			return nil, fmt.Errorf("error reading kerberos ticket cache: %s", err)
+		}
+		kc, err := client.NewClientFromCCache(tc, config.NewConfig())
+		if err != nil {
+			return nil, fmt.Errorf("error creating kerberos client: %s", err)
+		}
+		kerberosClient = kc
+	} else {
+		cfg, err := config.Load(krb5Conf)
+		if err != nil {
+			return nil, fmt.Errorf("error reading kerberos config: %s", err)
+		}
+		kt, err := keytab.Load(keyTab)
+		if err != nil {
+			return nil, fmt.Errorf("error reading kerberos keytab: %s", err)
+		}
+		kc := client.NewClientWithKeytab(username, realm, kt, cfg)
+		err = kc.Login()
+		if err != nil {
+			return nil, fmt.Errorf("error performing kerberos login with keytab: %s", err)
+		}
+		kerberosClient = kc
+	}
+	rt := &krb5Transport{cli.Transport, kerberosClient}
+	cli.Transport = rt
+	return cli, nil
+}
+
+// WithAdditionalHeaders wraps a http client to always include the given set of headers
+func WithAdditionalHeaders(cli *http.Client, headers http.Header) *http.Client {
+	rt := &additionalHeaderTransport{cli.Transport, headers}
+	cli.Transport = rt
+	return cli
+}
+
+type basicAuthTransport struct {
+	baseTransport      http.RoundTripper
+	username, password string
+}
+
+// RoundTrip implements the http.RoundTripper interface
+func (t *basicAuthTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	req.SetBasicAuth(t.username, t.password)
+	return t.baseTransport.RoundTrip(req)
+}
+
+type krb5Transport struct {
+	baseTransport  http.RoundTripper
+	kerberosClient *client.Client
+}
+
+// RoundTrip implements the http.RoundTripper interface
+func (t *krb5Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	err = gokrbSPNEGO.SetSPNEGOHeader(t.kerberosClient, req, "")
+	if err != nil {
+		return nil, err
+	}
+	return t.baseTransport.RoundTrip(req)
+}
+
+type additionalHeaderTransport struct {
+	baseTransport http.RoundTripper
+	headers       http.Header
+}
+
+func (t *additionalHeaderTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	for key, vals := range t.headers {
+		req.Header[key] = append(req.Header[key], vals...)
+	}
+	return t.baseTransport.RoundTrip(req)
+}

--- a/site/_docs/go_client_reference.md
+++ b/site/_docs/go_client_reference.md
@@ -71,7 +71,7 @@ rows := db.Query("SELECT COUNT(*) FROM test")
 The DSN has the following format (optional parts are marked by square brackets):
 
 {% highlight shell %}
-http://[username:password@]address:port[/schema][?parameter1=value&...parameterN=value]
+http://address:port[/schema][?parameter1=value&...parameterN=value]
 {% endhighlight %}
 
 In other words, the scheme (http), address and port are mandatory, but the schema and parameters are optional.
@@ -81,16 +81,6 @@ It's a shame that we have to embed HTML to get the anchors but the normal
 header tags from kramdown screw up the definition list. We lose the pretty
 on-hover images for the permalink, but oh well.
 {% endcomment %}
-
-<strong><a name="username" href="#username">username</a></strong>
-
-This is the JDBC username that is passed directly to the backing database. It is *NOT* used for authenticating
-against Avatica.
-
-<strong><a name="password" href="#password">password</a></strong>
-
-This is the JDBC password that is passed directly to the backing database. It is *NOT* used for authenticating
-against Avatica.
 
 <strong><a name="schema" href="#schema">schema</a></strong>
 


### PR DESCRIPTION
**What**

* adds an implementation for `driver.Connector` to the project.
* allows passing in arbitary infos and headers to do all kinds of auth stuff

**Why**

* we want to use that driver to connect to an endpoint behind an auth proxy and need to add some headers.
* Now its possible to attach other infos than the default ones to the connection to make it possible for a wrapping layer around to act accordingly 