### PR TITLE
harden error parsing.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -216,6 +216,11 @@ func (c *conn) avaticaErrorToResponseErrorOrError(err error) error {
 		return c.adapter.ErrorResponseToResponseError(avaticaErr.message)
 	}
 
+	serverAddress := "unknown"
+	md := avaticaErr.message.GetMetadata()
+	if md != nil {
+		serverAddress = md.ServerAddress
+	}
 	return errors.ResponseError{
 		Exceptions:   avaticaErr.message.Exceptions,
 		ErrorMessage: avaticaErr.message.ErrorMessage,
@@ -223,7 +228,7 @@ func (c *conn) avaticaErrorToResponseErrorOrError(err error) error {
 		ErrorCode:    errors.ErrorCode(avaticaErr.message.ErrorCode),
 		SqlState:     errors.SQLState(avaticaErr.message.SqlState),
 		Metadata: &errors.RPCMetadata{
-			ServerAddress: avaticaErr.message.GetMetadata().ServerAddress,
+			ServerAddress: serverAddress,
 		},
 	}
 }


### PR DESCRIPTION
This adds a nil check in the error parsing of the connection code. The old code assumes that the server always sends metadata in the ErrorResponse message. Because this is an embedded message in the protobuf definition it is compiled to a pointer and can therefore be nil.

I think even if setting this is manadatory (I dont know for sure) it will be useful to have more hardened error handling. Now the code will just panic and dont reveil any additional info about the problem.

If this seems to be mergeable I'll add a bug id from jira and will format my commit accordingly ;-)