### PR TITLE
[CALCITE-3264] add catch-all type for unknown types in generic adapter

### DIFF
--- a/generic/generic.go
+++ b/generic/generic.go
@@ -18,7 +18,6 @@
 package generic
 
 import (
-	"fmt"
 	"math"
 	"reflect"
 	"time"
@@ -88,7 +87,7 @@ func (a Adapter) GetColumnTypeDefinition(col *message.ColumnMetaData) *internal.
 		column.ScanType = reflect.TypeOf([]byte{})
 
 	default:
-		panic(fmt.Sprintf("scantype for %s is not implemented", col.Type.Name))
+		column.ScanType = reflect.TypeOf(new(interface{})).Elem()
 	}
 
 	// Handle rep type special cases for decimals, floats, date, time and timestamp

--- a/hsqldb/hsqldb.go
+++ b/hsqldb/hsqldb.go
@@ -18,7 +18,6 @@
 package hsqldb
 
 import (
-	"fmt"
 	"math"
 	"reflect"
 	"time"
@@ -88,7 +87,7 @@ func (a Adapter) GetColumnTypeDefinition(col *message.ColumnMetaData) *internal.
 		column.ScanType = reflect.TypeOf([]byte{})
 
 	default:
-		panic(fmt.Sprintf("scantype for %s is not implemented", col.Type.Name))
+		column.ScanType = reflect.TypeOf(new(interface{})).Elem()
 	}
 
 	// Handle rep type special cases for decimals, floats, date, time and timestamp

--- a/phoenix/phoenix.go
+++ b/phoenix/phoenix.go
@@ -18,7 +18,6 @@
 package phoenix
 
 import (
-	"fmt"
 	"math"
 	"reflect"
 	"regexp"
@@ -92,7 +91,7 @@ func (a Adapter) GetColumnTypeDefinition(col *message.ColumnMetaData) *internal.
 		column.ScanType = reflect.TypeOf([]byte{})
 
 	default:
-		panic(fmt.Sprintf("scantype for %s is not implemented", col.Type.Name))
+		column.ScanType = reflect.TypeOf(new(interface{})).Elem()
 	}
 
 	// Handle rep type special cases for decimals, floats, date, time and timestamp


### PR DESCRIPTION
Currently the generic adapter in the calcite-go driver panics when it sees an unknown type.

I as a user of the driver would like to see it either just working as expected or at least see a meaningfull error.

This PR adds a default scan type in the case that the column type is not recognized.