### PR TITLE
Add more nil checks in error handling.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -216,11 +216,6 @@ func (c *conn) avaticaErrorToResponseErrorOrError(err error) error {
 		return c.adapter.ErrorResponseToResponseError(avaticaErr.message)
 	}
 
-	serverAddress := "unknown"
-	md := avaticaErr.message.GetMetadata()
-	if md != nil {
-		serverAddress = md.ServerAddress
-	}
 	return errors.ResponseError{
 		Exceptions:   avaticaErr.message.Exceptions,
 		ErrorMessage: avaticaErr.message.ErrorMessage,
@@ -228,7 +223,7 @@ func (c *conn) avaticaErrorToResponseErrorOrError(err error) error {
 		ErrorCode:    errors.ErrorCode(avaticaErr.message.ErrorCode),
 		SqlState:     errors.SQLState(avaticaErr.message.SqlState),
 		Metadata: &errors.RPCMetadata{
-			ServerAddress: serverAddress,
+			ServerAddress: message.ServerAddressFromMetadata(avaticaErr.message),
 		},
 	}
 }

--- a/generic/generic.go
+++ b/generic/generic.go
@@ -109,16 +109,15 @@ func (a Adapter) GetColumnTypeDefinition(col *message.ColumnMetaData) *internal.
 	return column
 }
 
-func (a Adapter) ErrorResponseToResponseError(message *message.ErrorResponse) errors.ResponseError {
-
+func (a Adapter) ErrorResponseToResponseError(err *message.ErrorResponse) errors.ResponseError {
 	return errors.ResponseError{
-		Exceptions:   message.Exceptions,
-		ErrorMessage: message.ErrorMessage,
-		Severity:     int8(message.Severity),
-		ErrorCode:    errors.ErrorCode(message.ErrorCode),
-		SqlState:     errors.SQLState(message.SqlState),
+		Exceptions:   err.Exceptions,
+		ErrorMessage: err.ErrorMessage,
+		Severity:     int8(err.Severity),
+		ErrorCode:    errors.ErrorCode(err.ErrorCode),
+		SqlState:     errors.SQLState(err.SqlState),
 		Metadata: &errors.RPCMetadata{
-			ServerAddress: message.GetMetadata().ServerAddress,
+			ServerAddress: message.ServerAddressFromMetadata(err),
 		},
 	}
 }

--- a/hsqldb/hsqldb.go
+++ b/hsqldb/hsqldb.go
@@ -109,16 +109,15 @@ func (a Adapter) GetColumnTypeDefinition(col *message.ColumnMetaData) *internal.
 	return column
 }
 
-func (a Adapter) ErrorResponseToResponseError(message *message.ErrorResponse) errors.ResponseError {
-
+func (a Adapter) ErrorResponseToResponseError(err *message.ErrorResponse) errors.ResponseError {
 	return errors.ResponseError{
-		Exceptions:   message.Exceptions,
-		ErrorMessage: message.ErrorMessage,
-		Severity:     int8(message.Severity),
-		ErrorCode:    errors.ErrorCode(message.ErrorCode),
-		SqlState:     errors.SQLState(message.SqlState),
+		Exceptions:   err.Exceptions,
+		ErrorMessage: err.ErrorMessage,
+		Severity:     int8(err.Severity),
+		ErrorCode:    errors.ErrorCode(err.ErrorCode),
+		SqlState:     errors.SQLState(err.SqlState),
 		Metadata: &errors.RPCMetadata{
-			ServerAddress: message.GetMetadata().ServerAddress,
+			ServerAddress: message.ServerAddressFromMetadata(err),
 		},
 	}
 }

--- a/message/helper.go
+++ b/message/helper.go
@@ -1,0 +1,14 @@
+package message
+
+type MetadataProvider interface {
+	GetMetadata() *RpcMetadata
+}
+
+func ServerAddressFromMetadata(message MetadataProvider) string {
+	serverAddress := "unknown"
+	md := message.GetMetadata()
+	if md != nil {
+		serverAddress = md.ServerAddress
+	}
+	return serverAddress
+}


### PR DESCRIPTION
This adds the same nil checks while parsing errors as in connection.go I added a few days ago. I'm greping around to find more missing nil checks, but these are the only three related to GetMetadata() that I could find.
 