### PR TITLE
Replace ExecuteRequest with ExecuteBatchRequest

### DIFF
--- a/class_mappings.go
+++ b/class_mappings.go
@@ -56,6 +56,8 @@ func classNameFromRequest(message interface{}) string {
 		class = "DatabasePropertyRequest"
 	case *avaticaMessage.ExecuteRequest:
 		class = "ExecuteRequest"
+	case *avaticaMessage.ExecuteBatchRequest:
+		class = "ExecuteBatchRequest"
 	case *avaticaMessage.FetchRequest:
 		class = "FetchRequest"
 	case *avaticaMessage.OpenConnectionRequest:
@@ -104,6 +106,8 @@ func responseFromClassName(className string) (proto.Message, error) {
 		return &avaticaMessage.ErrorResponse{}, nil
 	case "ExecuteResponse":
 		return &avaticaMessage.ExecuteResponse{}, nil
+	case "ExecuteBatchResponse":
+		return &avaticaMessage.ExecuteBatchResponse{}, nil
 	case "FetchResponse":
 		return &avaticaMessage.FetchResponse{}, nil
 	case "OpenConnectionResponse":

--- a/connection.go
+++ b/connection.go
@@ -20,7 +20,6 @@ package avatica
 import (
 	"context"
 	"database/sql/driver"
-
 	"github.com/apache/calcite-avatica-go/v4/errors"
 	"github.com/apache/calcite-avatica-go/v4/message"
 	"golang.org/x/xerrors"
@@ -56,10 +55,11 @@ func (c *conn) prepare(ctx context.Context, query string) (driver.Stmt, error) {
 	prepareResponse := response.(*message.PrepareResponse)
 
 	return &stmt{
-		statementID: prepareResponse.Statement.Id,
-		conn:        c,
-		parameters:  prepareResponse.Statement.Signature.Parameters,
-		handle:      *prepareResponse.Statement,
+		statementID:  prepareResponse.Statement.Id,
+		conn:         c,
+		parameters:   prepareResponse.Statement.Signature.Parameters,
+		handle:       *prepareResponse.Statement,
+		batchUpdates: make([]*message.UpdateBatch, 0),
 	}, nil
 }
 
@@ -117,9 +117,7 @@ func (c *conn) begin(ctx context.Context, isolationLevel isoLevel) (driver.Tx, e
 		return nil, c.avaticaErrorToResponseErrorOrError(err)
 	}
 
-	return &tx{
-		conn: c,
-	}, nil
+	return &tx{conn: c}, nil
 }
 
 // Exec prepares and executes a query and returns the result directly.

--- a/driver_phoenix_test.go
+++ b/driver_phoenix_test.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -1377,4 +1378,123 @@ func TestPhoenixErrorCodeParsing(t *testing.T) {
 	if resErr.SqlState != "42M03" {
 		t.Errorf("Expected SQL state to be %s, got %s.", "42M03", resErr.SqlState)
 	}
+}
+
+func TestPhoenixExecBatch(t *testing.T) {
+	skipTestIfNotPhoenix(t)
+
+	runTests(t, dsn+"?batching=true", func(dbt *DBTest) {
+
+		// Create and seed table
+		dbt.mustExec(`CREATE TABLE ` + dbt.tableName + ` (
+				int INTEGER PRIMARY KEY
+			    ) TRANSACTIONAL=false`)
+
+		stmt, err := dbt.db.Prepare(`UPSERT INTO ` + dbt.tableName + ` VALUES(?)`)
+
+		if err != nil {
+			dbt.Fatal(err)
+		}
+
+		totalRows := 6
+
+		for i := 1; i <= totalRows; i++ {
+			_, err := stmt.Exec(i)
+
+			if err != nil {
+				dbt.Fatal(err)
+			}
+		}
+
+		// When batching=true, after exec(sql), need to close the stmt
+		err = stmt.Close()
+
+		if err != nil {
+			dbt.Fatal(err)
+		}
+
+		queryStmt, err := dbt.db.Prepare(`SELECT * FROM ` + dbt.tableName + ` WHERE int = ?`)
+
+		if err != nil {
+			dbt.Fatal(err)
+		}
+
+		var res int
+
+		for i := 1; i <= totalRows; i++ {
+
+			err := queryStmt.QueryRow(i).Scan(&res)
+
+			if err != nil {
+				dbt.Fatal(err)
+			}
+
+			if res != i {
+				dbt.Fatalf("Unexpected query result. Expected %d, got %d.", i, res)
+			}
+		}
+	})
+}
+
+func TestPhoenixExecBatchConcurrency(t *testing.T) {
+	skipTestIfNotPhoenix(t)
+
+	runTests(t, dsn+"?batching=true", func(dbt *DBTest) {
+
+		// Create and seed table
+		dbt.mustExec(`CREATE TABLE ` + dbt.tableName + ` (
+				int INTEGER PRIMARY KEY
+			    ) TRANSACTIONAL=false`)
+
+		stmt, err := dbt.db.Prepare(`UPSERT INTO ` + dbt.tableName + ` VALUES(?)`)
+
+		if err != nil {
+			dbt.Fatal(err)
+		}
+
+		totalRows := 6
+
+		var wg sync.WaitGroup
+		for i := 1; i <= totalRows; i++ {
+			wg.Add(1)
+			go func(num int) {
+				defer wg.Done()
+
+				_, err := stmt.Exec(num)
+
+				if err != nil {
+					dbt.Fatal(err)
+				}
+			}(i)
+		}
+		wg.Wait()
+
+		// When batching=true, after exec(sql), need to close the stmt
+		err = stmt.Close()
+
+		if err != nil {
+			dbt.Fatal(err)
+		}
+
+		queryStmt, err := dbt.db.Prepare(`SELECT * FROM ` + dbt.tableName + ` WHERE int = ?`)
+
+		if err != nil {
+			dbt.Fatal(err)
+		}
+
+		var res int
+
+		for i := 1; i <= totalRows; i++ {
+
+			err := queryStmt.QueryRow(i).Scan(&res)
+
+			if err != nil {
+				dbt.Fatal(err)
+			}
+
+			if res != i {
+				dbt.Fatalf("Unexpected query result. Expected %d, got %d.", i, res)
+			}
+		}
+	})
 }

--- a/dsn.go
+++ b/dsn.go
@@ -43,6 +43,7 @@ type Config struct {
 	location             *time.Location
 	schema               string
 	transactionIsolation uint32
+	batching             bool
 
 	authentication      authentication
 	avaticaUser         string
@@ -66,6 +67,7 @@ func ParseDSN(dsn string) (*Config, error) {
 		frameMaxSize:         -1,
 		location:             time.UTC,
 		transactionIsolation: 0,
+		batching:             false,
 	}
 
 	parsed, err := url.ParseRequestURI(dsn)
@@ -122,6 +124,12 @@ func ParseDSN(dsn string) (*Config, error) {
 		}
 
 		conf.transactionIsolation = uint32(isolation)
+	}
+
+	if v := queries.Get("batching"); v != "" {
+		if v == "true" {
+			conf.batching = true
+		}
 	}
 
 	if v := queries.Get("authentication"); v != "" {

--- a/statement.go
+++ b/statement.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/apache/calcite-avatica-go/v4/message"
@@ -28,10 +29,12 @@ import (
 )
 
 type stmt struct {
-	statementID uint32
-	conn        *conn
-	parameters  []*message.AvaticaParameter
-	handle      message.StatementHandle
+	statementID  uint32
+	conn         *conn
+	parameters   []*message.AvaticaParameter
+	handle       message.StatementHandle
+	batchUpdates []*message.UpdateBatch
+	sync.Mutex
 }
 
 // Close closes a statement
@@ -39,6 +42,17 @@ func (s *stmt) Close() error {
 
 	if s.conn.connectionId == "" {
 		return driver.ErrBadConn
+	}
+
+	if s.conn.config.batching {
+		_, err := s.conn.httpClient.post(context.Background(), &message.ExecuteBatchRequest{
+			ConnectionId: s.conn.connectionId,
+			StatementId:  s.statementID,
+			Updates:      s.batchUpdates,
+		})
+		if err != nil {
+			return s.conn.avaticaErrorToResponseErrorOrError(err)
+		}
 	}
 
 	_, err := s.conn.httpClient.post(context.Background(), &message.CloseStatementRequest{
@@ -79,9 +93,23 @@ func (s *stmt) exec(ctx context.Context, args []namedValue) (driver.Result, erro
 		return nil, driver.ErrBadConn
 	}
 
+	values := s.parametersToTypedValues(args)
+
+	if s.conn.config.batching {
+		s.Lock()
+		defer s.Unlock()
+
+		s.batchUpdates = append(s.batchUpdates, &message.UpdateBatch{
+			ParameterValues: values,
+		})
+		return &result{
+			affectedRows: -1,
+		}, nil
+	}
+
 	msg := &message.ExecuteRequest{
 		StatementHandle:    &s.handle,
-		ParameterValues:    s.parametersToTypedValues(args),
+		ParameterValues:    values,
 		FirstFrameMaxSize:  s.conn.config.frameMaxSize,
 		HasParameterValues: true,
 	}


### PR DESCRIPTION
Where writing a large amount of data, ExecuteRequest need to send multiple http requests. We hope that ExecuteBatchRequest can be used instead of ExecuteRequest to reduce the number of data transmissions as much as possible.