### PR TITLE
[CALCITE-5072] Index out of range when calling rows.Next()

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -20,6 +20,7 @@ package avatica
 import (
 	"context"
 	"database/sql/driver"
+	"errors"
 	"io"
 	"time"
 
@@ -80,7 +81,7 @@ func (r *rows) Close() error {
 // Next should return io.EOF when there are no more rows.
 func (r *rows) Next(dest []driver.Value) error {
 	if len(r.resultSets) == 0 {
-		return io.EOF
+		return errors.New("r.resultSets len == 0")
 	}
 	resultSet := r.resultSets[r.currentResultSet]
 

--- a/rows.go
+++ b/rows.go
@@ -20,7 +20,6 @@ package avatica
 import (
 	"context"
 	"database/sql/driver"
-	"errors"
 	"io"
 	"time"
 
@@ -81,7 +80,7 @@ func (r *rows) Close() error {
 // Next should return io.EOF when there are no more rows.
 func (r *rows) Next(dest []driver.Value) error {
 	if len(r.resultSets) == 0 {
-		return errors.New("r.resultSets len == 0")
+		return io.EOF
 	}
 	resultSet := r.resultSets[r.currentResultSet]
 

--- a/rows.go
+++ b/rows.go
@@ -79,7 +79,9 @@ func (r *rows) Close() error {
 //
 // Next should return io.EOF when there are no more rows.
 func (r *rows) Next(dest []driver.Value) error {
-
+	if len(r.resultSets) == 0 {
+		return io.EOF
+	}
 	resultSet := r.resultSets[r.currentResultSet]
 
 	if resultSet.currentRow >= len(resultSet.data) {

--- a/rows.go
+++ b/rows.go
@@ -52,6 +52,9 @@ func (r *rows) Columns() []string {
 		return r.columnNames
 	}
 	var cols []string
+	if len(r.resultSets) == 0 {
+		return cols
+	}
 	for _, column := range r.resultSets[r.currentResultSet].columns {
 		cols = append(cols, column.Name)
 	}

--- a/rows.go
+++ b/rows.go
@@ -40,6 +40,7 @@ type rows struct {
 	statementID      uint32
 	resultSets       []*resultSet
 	currentResultSet int
+	columnNames      []string
 }
 
 // Columns returns the names of the columns. The number of
@@ -47,13 +48,14 @@ type rows struct {
 // slice.  If a particular column name isn't known, an empty
 // string should be returned for that entry.
 func (r *rows) Columns() []string {
-
+	if r.columnNames != nil {
+		return r.columnNames
+	}
 	var cols []string
-
 	for _, column := range r.resultSets[r.currentResultSet].columns {
 		cols = append(cols, column.Name)
 	}
-
+	r.columnNames = cols
 	return cols
 }
 


### PR DESCRIPTION
fix index ount of bound panic. 
https://github.com/grafana/loki/pull/5692/
[new feature] Index: loki support apache calcite avatica index storage. #5692

I implemented the index storage plugin of apache avatic in the grafana loki community, and found that avatica-go would panic in the online environment. This PR attempts to fix this panic. Our online loki has been fixed.

```shell
panic: runtime error: index out of range [0] with length 0 
	/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/apache/calcite-avatica-go/v5.(*rows).Columns(0x4cc4b7)
	/Users/fuling/go/pkg/mod/github.com/liguozhong/calcite-avatica-go/v5@v5.1.1-0.20220330132417-bb5de288ce8c/rows.go:55 +0x17b
database/sql.(*Rows).nextLocked(0xc038348000)
	/usr/local/go/src/database/sql/sql.go:2964 +0xb0
database/sql.(*Rows).Next.func1()
	/usr/local/go/src/database/sql/sql.go:2945 +0x2f
database/sql.withLock({0x32a6008, 0xc038348030}, 0xc004cb76f0)
	/usr/local/go/src/database/sql/sql.go:3396 +0x8c
database/sql.(*Rows).Next(0xc038348000)
	/usr/local/go/src/database/sql/sql.go:2944 +0x6f
github.com/grafana/loki/pkg/storage/chunk/avatica.(*StorageClient).query(0xc001024ea0, {0x32d98a8, 0xc0188ef320}, {{0xc00589f300, 0x1e}, {0xc01bc60990, 0x2b}, {0x0, 0x0, 0x0}, ...}, ...)
```

code in loki,	for rows.Next() { panic.
```go
case query.ValueEqual != nil:
		querySQL = fmt.Sprintf("SELECT range, value FROM %s WHERE hash = ? AND value = ? ALLOW FILTERING",
			query.TableName)
		queryFunc = func() error {
			rows, err = s.readSession.QueryContext(ctx, querySQL, query.HashValue, query.ValueEqual)
			return err
		}
	}

	retries := backoff.New(ctx, s.cfg.BackoffConfig)
	err = ctx.Err()
	for retries.Ongoing() {
		err = s.queryInstrumentation(ctx, querySQL, queryFunc)
		if err == nil {
			break
		}
		retries.Wait()
	}
	if err != nil {
		level.Error(util_log.Logger).Log("msg", "avatica QUERY fail", "sql", querySQL, "err", err)
		return errors.WithStack(err)
	}
	defer rows.Close()
	for rows.Next() {
		b := &readBatch{}
		err = rows.Scan(&b.rangeValue, &b.value)
		if err != nil {
			return errors.WithStack(err)
		}
		if !callback(query, b) {
			return nil
		}
	}
```

``` go
func (s *StorageClient) queryInstrumentation(ctx context.Context, query string, queryFunc func() error) error {
	var start time.Time
	var end time.Time
	var err error
	sp := ot.SpanFromContext(ctx)
	sp.SetTag("sql", query)

	defer func() {
		statusCode := "200"
		if err != nil {
			level.Warn(util_log.Logger).Log("msg", "avatica query fail", "sql", query, "err", err)
			statusCode = "500"
			ext.Error.Set(sp, true)
			sp.LogFields(otlog.String("event", "error"), otlog.String("message", err.Error()))
		}
		parts := strings.SplitN(query, " ", 2)
		requestDuration.WithLabelValues(parts[0], statusCode).Observe(end.Sub(start).Seconds())
	}()
	start = time.Now()
	err = queryFunc()
	end = time.Now()
	if err != nil {
		return errors.WithStack(err)
	}
	return nil
}
```

