### PR TITLE
[CALCITE-5077] ResetSession implements driver.SessionResetter.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -27,10 +27,11 @@ import (
 )
 
 type conn struct {
-	connectionId string
-	config       *Config
-	httpClient   *httpClient
-	adapter      Adapter
+	connectionId  string
+	config        *Config
+	httpClient    *httpClient
+	adapter       Adapter
+	connectorInfo map[string]string
 }
 
 // Prepare returns a prepared statement, bound to this connection.
@@ -228,4 +229,17 @@ func (c *conn) avaticaErrorToResponseErrorOrError(err error) error {
 			ServerAddress: message.ServerAddressFromMetadata(avaticaErr.message),
 		},
 	}
+}
+
+// ResetSession implements driver.SessionResetter.
+// (From Go 1.10)
+func (c *conn) ResetSession(ctx context.Context) error {
+	if c.connectionId == "" {
+		return driver.ErrBadConn
+	}
+	err := registerConn(c)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
avatica sql query fails after running for a period of time on our online loki, this PR attempts to solve this "NoSuchConnectionException" problem.

```shell
level=error ts=2022-03-31T12:51:09.356233496Z caller=table_manager.go:233 msg="error syncing tables" err="An error was encountered while processing your request: NoSuchConnectionException{connectionId='Connection not found: invalid id, closed, or expired: ccd95a16-5496-7001-f99b-1ab0e5f19e05'}"
```