### PR TITLE
[CALCITE-5077] ResetSession implements driver.SessionResetter. 

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -27,10 +27,11 @@ import (
 )
 
 type conn struct {
-	connectionId string
-	config       *Config
-	httpClient   *httpClient
-	adapter      Adapter
+	connectionId  string
+	config        *Config
+	httpClient    *httpClient
+	adapter       Adapter
+	connectorInfo map[string]string
 }
 
 // Prepare returns a prepared statement, bound to this connection.
@@ -228,4 +229,17 @@ func (c *conn) avaticaErrorToResponseErrorOrError(err error) error {
 			ServerAddress: message.ServerAddressFromMetadata(avaticaErr.message),
 		},
 	}
+}
+
+// ResetSession implements driver.SessionResetter.
+// (From Go 1.10)
+func (c *conn) ResetSession(ctx context.Context) error {
+	if c.connectionId == "" {
+		return driver.ErrBadConn
+	}
+	err := registerConn(c)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/driver.go
+++ b/driver.go
@@ -22,10 +22,10 @@ Quickstart
 
 Import the database/sql package along with the avatica driver.
 
-	import "database/sql"
-	import _ "github.com/apache/calcite-avatica-go/v5"
+  import "database/sql"
+  import _ "github.com/apache/calcite-avatica-go/v5"
 
-	db, err := sql.Open("avatica", "http://phoenix-query-server:8765")
+  db, err := sql.Open("avatica", "http://phoenix-query-server:8765")
 
 See https://calcite.apache.org/avatica/docs/go_client_reference.html for more details
 */
@@ -68,51 +68,27 @@ func (c *Connector) Connect(context.Context) (driver.Conn, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to open connection: %w", err)
 	}
-
+	connectionId, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("error generating connection id: %w", err)
+	}
 	httpClient, err := NewHTTPClient(config.endpoint, c.Client, config)
 
 	if err != nil {
 		return nil, fmt.Errorf("unable to create HTTP client: %w", err)
 	}
-
-	connectionId, err := uuid.GenerateUUID()
-	if err != nil {
-		return nil, fmt.Errorf("error generating connection id: %w", err)
-	}
-
-	info := map[string]string{
-		"AutoCommit":  "true",
-		"Consistency": "8",
-	}
-
-	for k, v := range c.Info {
-		info[k] = v
-	}
-
 	conn := &conn{
-		connectionId: connectionId,
-		httpClient:   httpClient,
-		config:       config,
+		connectionId:  connectionId,
+		httpClient:    httpClient,
+		config:        config,
+		connectorInfo: c.Info,
 	}
-
-	// Open a connection to the server
-	req := &message.OpenConnectionRequest{
-		ConnectionId: connectionId,
-		Info:         info,
-	}
-
-	if config.schema != "" {
-		req.Info["schema"] = config.schema
-	}
-
-	_, err = httpClient.post(context.Background(), req)
-
+	err = registerConn(conn)
 	if err != nil {
-		return nil, conn.avaticaErrorToResponseErrorOrError(err)
+		return nil, err
 	}
-
-	response, err := httpClient.post(context.Background(), &message.DatabasePropertyRequest{
-		ConnectionId: connectionId,
+	response, err := conn.httpClient.post(context.Background(), &message.DatabasePropertyRequest{
+		ConnectionId: conn.connectionId,
 	})
 
 	if err != nil {
@@ -132,6 +108,29 @@ func (c *Connector) Connect(context.Context) (driver.Conn, error) {
 	conn.adapter = getAdapter(adapter)
 
 	return conn, nil
+}
+
+func registerConn(conn *conn) error {
+	info := map[string]string{
+		"AutoCommit":  "true",
+		"Consistency": "8",
+	}
+	for k, v := range conn.connectorInfo {
+		info[k] = v
+	}
+	// Open a connection to the server
+	req := &message.OpenConnectionRequest{
+		ConnectionId: conn.connectionId,
+		Info:         info,
+	}
+	if conn.config.schema != "" {
+		req.Info["schema"] = conn.config.schema
+	}
+	_, err := conn.httpClient.post(context.Background(), req)
+	if err != nil {
+		return conn.avaticaErrorToResponseErrorOrError(err)
+	}
+	return nil
 }
 
 // Driver returns the underlying driver


### PR DESCRIPTION
avatica sql query fails after running for a period of time on our online loki, this PR attempts to solve this "NoSuchConnectionException" problem.

level=error ts=2022-03-31T12:51:09.356233496Z caller=table_manager.go:233 msg="error syncing tables" err="An error was encountered while processing your request: NoSuchConnectionException{connectionId='Connection not found: invalid id, closed, or expired: ccd95a16-5496-7001-f99b-1ab0e5f19e05'}"
