### PR TITLE
[CALCITE-5758] Initialize connector info map to prevent panic

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -58,7 +58,10 @@ type Connector struct {
 
 // NewConnector creates a new connector
 func NewConnector(dsn string) driver.Connector {
-	return &Connector{nil, nil, dsn}
+	return &Connector{
+		Info: make(map[string]string),
+		dsn:  dsn,
+	}
 }
 
 func (c *Connector) Connect(context.Context) (driver.Conn, error) {


### PR DESCRIPTION
Missed this initialization in https://github.com/apache/calcite-avatica-go/pull/65 causing `panic: assignment to entry in nil map` while setting user and pwd in `c.Info`