### PR TITLE
[CALCITE-7136] Add Support for Druid Double Types

### DIFF
--- a/generic/generic.go
+++ b/generic/generic.go
@@ -96,6 +96,8 @@ func (a Adapter) GetColumnTypeDefinition(col *message.ColumnMetaData) *internal.
 		column.Rep = message.Rep_BIG_DECIMAL
 	case "FLOAT", "REAL":
 		column.Rep = message.Rep_FLOAT
+	case "DOUBLE":
+		column.Rep = message.Rep_DOUBLE
 	case "TIME":
 		column.Rep = message.Rep_JAVA_SQL_TIME
 	case "DATE":


### PR DESCRIPTION
Using the std golang sql package, `Scan` functionality will quietly fail and the zero value will be used. 

During the prepare phase of the sql request the correct types are returned.
xxx_hidden_ColumnClassName ="java.lang.Double"
xxx_hidden_Name ="DOUBLE"
xxx_hidden_Rep =Rep_NUMBER (22)

Special handling already exists for things such as floats and reals. Adding a doubles case solves the issue.