### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,12 +24,25 @@ github:
   enabled_merge_buttons:
     # "squash and merge" replaces committer with noreply@github, and we don't want that
     # See https://lists.apache.org/thread/vxxpt1x316kjryb4dptsbs95p66d9xrv
-    squash:  false
+    squash: false
     # We prefer linear history, so creating merge commits is disabled in UI
-    merge:   false
-    rebase:  true
+    merge: false
+    rebase: true
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
-  commits:      commits@calcite.apache.org
-  issues:       issues@calcite.apache.org
+  commits: commits@calcite.apache.org
+  issues: issues@calcite.apache.org
   pullrequests: commits@calcite.apache.org
   jira_options: link label


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
